### PR TITLE
Add save_and_reload_df decorator and minor modifs

### DIFF
--- a/tools/data_exploration.py
+++ b/tools/data_exploration.py
@@ -12,8 +12,8 @@ def print_email_by_id(df_emails, mid):
             - mid (int)
     '''
     email_dict = df_emails.loc[mid].to_dict()
-    email_content = "From: {sender} \nTo: {recipients}\nOn: {date} \n\
-Body:\n {body}".format(**email_dict)
+    email_content = "From: {sender}\nTo: {recipients}\nOn: {date}\n\
+Body:\n    {body}".format(**email_dict)
     print(email_content)
 
 

--- a/tools/data_handling.py
+++ b/tools/data_handling.py
@@ -2,6 +2,8 @@ import os.path as op
 
 import pandas as pd
 
+from tools.utils import save_and_reload_df
+
 DATA_FOLDER = "data"
 
 
@@ -12,8 +14,7 @@ def load_emails():
             recipients] and the id is mid.
     '''
     training_info_path = op.join(DATA_FOLDER, "training_info.csv")
-    df_emails = pd.read_csv(training_info_path)
-    df_emails = df_emails.set_index("mid")
+    df_emails = pd.read_csv(training_info_path, index_col=0)
     return df_emails
 
 
@@ -26,29 +27,19 @@ def load_email_senders():
     return pd.read_csv(training_set_path)
 
 
-def enrich_emails(overwrite=False):
-    '''Adds the sender column to the emails dataframe and returns it. By
-    default takes it from "training_info_enriched.csv".
-        Arguments:
-            - overwrite (bool): whether you want to recompute the enrichment.
-            If True, the enrichment will be recomputed and the file
-            overwritten.
+@save_and_reload_df
+def enrich_emails():
+    '''Adds the sender column to the emails dataframe and returns it.
         Output:
             - pd dataframe: the emails enriched. The columns are [mid, date,
             body, recipients, sender]
     '''
-    enriched_emails_path = op.join(DATA_FOLDER, "training_info_enriched.csv")
-    if overwrite or not op.exists(enriched_emails_path):
-        df_emails = load_emails()
-        df_email_senders = load_email_senders()
-        df_emails["sender"] = ""
-        for index, row in df_email_senders.iterrows():
-            for mid in row["mids"].split():
-                df_emails.set_value(int(mid), "sender", row["sender"])
-        df_emails.to_csv(enriched_emails_path)
-    else:
-        df_emails = pd.read_csv(enriched_emails_path)
-        df_emails = df_emails.set_index("mid")
+    df_emails = load_emails()
+    df_email_senders = load_email_senders()
+    df_emails["sender"] = ""
+    for index, row in df_email_senders.iterrows():
+        for mid in row["mids"].split():
+            df_emails.set_value(int(mid), "sender", row["sender"])
     return df_emails
 
 


### PR DESCRIPTION
Add save_and_reload_df decorator and minor modifs

Usage:
```
@save_and_reload_df
def my_func():
    # Create and fill the dataframe
    df = pd.DataFrame(...)
    df = ...
    return df
```

What the decorator does:
On the first execution of the function, it will retrieve the returned dataframe and save it at `data/my_func.csv`.
When the function is called again, if the file `data/my_func.csv` exists, it will not call `my_func()` but just read the file and return the dataframe.
If one wants to compute the dataframe again, just call `my_func(overwrite=True)` (argument added automatically by the decorator), the decorator will call the function, save  and return the new dataframe. 